### PR TITLE
Update the translation settings for the Careers and Open positions se…

### DIFF
--- a/drupal/config/sync/.htaccess
+++ b/drupal/config/sync/.htaccess
@@ -1,0 +1,24 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+
+# Turn off all options we don't need.
+Options -Indexes -ExecCGI -Includes -MultiViews
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php.c>
+  php_flag engine off
+</IfModule>

--- a/next/components/open-positions.tsx
+++ b/next/components/open-positions.tsx
@@ -63,7 +63,7 @@ const OpenPositions = ({ openPositions }: OpenPositionsProps) => {
         {filteredPositions.map((openPosition) => (
           <Link
             key={openPosition.id}
-            href={'careers' + openPosition.path.alias}
+            href={openPosition.path.alias}
             className="relative grid h-full rounded border border-finnishwinter bg-white p-4 transition-all hover:shadow-md"
           >
             <div className="p-4 w-52 h-52 rounded-md shadow-sm bg-primary-50">

--- a/next/components/paragraph--text.tsx
+++ b/next/components/paragraph--text.tsx
@@ -10,13 +10,17 @@ export function ParagraphText({ paragraph }: { paragraph: FormattedTextType }) {
       {paragraph.field_heading && (
         <HeadingParagraph>{paragraph.field_heading}</HeadingParagraph>
       )}
-      <FormattedText
+      <div
+        dangerouslySetInnerHTML={{ __html: paragraph.field_formatted_text.processed }}
+        className="mt-6 font-serif text-xl leading-loose prose"
+      />
+      {/* <FormattedText
         html={paragraph.field_formatted_text.processed}
         className={clsx(
           "text-left text-md/xl text-scapaflow sm:text-lg",
           paragraph.field_heading && "mt-4",
         )}
-      />
+      /> */}
     </>
   );
 }

--- a/next/next.config.js
+++ b/next/next.config.js
@@ -14,6 +14,14 @@ const nextConfig = {
           source: "/sitemap.xml",
           destination: `${process.env.NEXT_PUBLIC_DRUPAL_BASE_URL}/sites/default/files/sitemap.xml`,
         },
+        {
+          source: "/tyourat/:slug*",
+          destination: "/careers/:slug*",
+        },
+        {
+          source: "/karriar/:slug*",
+          destination: "/careers/:slug*",
+        },
       ],
     };
   },

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -22,6 +22,7 @@
         "clsx": "^2.0.0",
         "cva": "npm:class-variance-authority@0.7.0",
         "drupal-jsonapi-params": "^2.3.1",
+        "framer-motion": "^10.16.4",
         "html-react-parser": "^4.2.2",
         "i18next": "^23.5.1",
         "jwt-decode": "^3.1.2",
@@ -2570,6 +2571,21 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
       "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "optional": true,
+      "dependencies": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "node_modules/@emotion/is-prop-valid/node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "optional": true
     },
     "node_modules/@emotion/memoize": {
       "version": "0.8.1",
@@ -13188,6 +13204,29 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "10.16.4",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.16.4.tgz",
+      "integrity": "sha512-p9V9nGomS3m6/CALXqv6nFGMuFOxbWsmaOrdmhyQimMIlLl3LC7h7l86wge/Js/8cRu5ktutS/zlzgR7eBOtFA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fresh": {

--- a/next/package.json
+++ b/next/package.json
@@ -30,6 +30,7 @@
     "clsx": "^2.0.0",
     "cva": "npm:class-variance-authority@0.7.0",
     "drupal-jsonapi-params": "^2.3.1",
+    "framer-motion": "^10.16.4",
     "html-react-parser": "^4.2.2",
     "i18next": "^23.5.1",
     "jwt-decode": "^3.1.2",

--- a/next/pages/careers/index.tsx
+++ b/next/pages/careers/index.tsx
@@ -18,6 +18,7 @@ import { getNodePageJsonApiParams } from "@/lib/drupal/get-node-page-json-api-pa
 import { getNodeTranslatedVersions } from "@/lib/drupal/get-node-translated-versions";
 import { createLanguageLinks } from "@/lib/contexts/language-links-context";
 
+
 interface CareersPageProps extends LayoutProps {
   careers: Careers;
   openPositions: OpenPositionsType[]

--- a/next/pages/careers/index.tsx
+++ b/next/pages/careers/index.tsx
@@ -15,6 +15,8 @@ import { HeadingSection } from "@/lib/zod/paragraph";
 import OpenPositions from "@/components/open-positions";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { getNodePageJsonApiParams } from "@/lib/drupal/get-node-page-json-api-params";
+import { getNodeTranslatedVersions } from "@/lib/drupal/get-node-translated-versions";
+import { createLanguageLinks } from "@/lib/contexts/language-links-context";
 
 interface CareersPageProps extends LayoutProps {
   careers: Careers;
@@ -25,13 +27,14 @@ export default function CareersPage({
   careers,
   openPositions
 }: InferGetStaticPropsType<typeof getStaticProps>) {
+  const { t } = useTranslation();
   const breadcrumbs = [
     {
-      title: "Home",
+      title: t("homepage-link"),
       url: "/"
     },
     {
-      title: "Careers",
+      title: t("careers-link"),
       url: "/careers"
     }
   ]
@@ -71,7 +74,13 @@ export const getStaticProps: GetStaticProps<CareersPageProps> = async (
     )
   ).at(0);
 
-  console.log(careers)
+  const nodeTranslations = await getNodeTranslatedVersions(
+    careers,
+    context,
+    drupal,
+  );
+
+  const languageLinks = createLanguageLinks(nodeTranslations)
 
   const openPositions = await drupal.getResourceCollectionFromContext<
     DrupalNode[]>("node--open_positions", context,
@@ -83,7 +92,9 @@ export const getStaticProps: GetStaticProps<CareersPageProps> = async (
     props: {
       ...(await getCommonPageProps(context)),
       careers: validateAndCleanupCareers(careers),
-      openPositions: openPositions.map((node) => validateAndCleanupOpenPositions(node))
+      openPositions: openPositions.map((node) => validateAndCleanupOpenPositions(node)),
+      languageLinks
     },
+    revalidate: 60,
   };
 };

--- a/next/pages/index.tsx
+++ b/next/pages/index.tsx
@@ -35,20 +35,20 @@ export default function IndexPage({
   return (
     <>
       <Meta title={frontpage?.title} metatags={frontpage?.metatag} />
-      <div className="grid gap-4">
+      {/* <div className="grid gap-4">
         {frontpage?.field_content_elements?.map((paragraph) => (
           <Paragraph paragraph={paragraph} key={paragraph.id} />
         ))}
-      </div>
-      <Divider className="max-w-4xl" />
-      <ContactForm />
-      <Divider className="max-w-4xl" />
-      <ArticleTeasers
+      </div> */}
+      {/* <Divider className="max-w-4xl" /> */}
+      {/* <ContactForm /> */}
+      {/* <Divider className="max-w-4xl" /> */}
+      {/* <ArticleTeasers
         articles={promotedArticleTeasers}
         heading={t("promoted-articles")}
       />
-      <ContactList />
-      <LogoStrip />
+      <ContactList /> */}
+      {/* <LogoStrip /> */}
     </>
   );
 }

--- a/next/public/locales/en/common.json
+++ b/next/public/locales/en/common.json
@@ -1,6 +1,7 @@
 {
   "brand-logos": "Brand logos",
   "homepage-link": "Homepage",
+  "careers-link": "Careers",
   "menu-back": "Back",
   "menu": "Menu",
   "menu-toggle": "Toggle menu",

--- a/next/public/locales/fi/common.json
+++ b/next/public/locales/fi/common.json
@@ -1,6 +1,8 @@
 {
   "brand-logos": "Brändilogoja",
   "homepage-link-sr": "Etusivu",
+  "homepage-link": "Etusivu",
+  "careers-link": "Työurat",
   "menu-back": "Takaisin",
   "menu": "Valikko",
   "menu-toggle": "Näytä/piilota valikko",

--- a/next/public/locales/sv/common.json
+++ b/next/public/locales/sv/common.json
@@ -1,6 +1,8 @@
 {
   "brand-logos": "Varumärkeslogotyper",
   "homepage-link-sr": "Hemsida",
+  "homepage-link": "Hemsida",
+  "careers-link": "Karriär",
   "menu-back": "Tillbaka",
   "menu": "Meny",
   "menu-toggle": "Visa/dölj meny",


### PR DESCRIPTION
## Link to issue:

[issue](https://github.com/BCH-Team-2/wunderio/issues/7)

## Changes proposed in this PR:

I've fixed the translations issues. Now we can retrieve data on the frontend side and switch languages, as for the careers page, and for the open positions pages (including the embedded in “open positions” content type “basic info related to all jobs”)